### PR TITLE
Auto-shutdown w/ grace period.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Updates
+Forked from [mailgun/manners](https://github.com/mailgun/manners).
+
+* Automatically listens for shutdown signals if manners.ListenAndServe, manners.ListenAndServeTLS, or manners.Serve is called.
+* Automatically calls manners.Close after a grace period when a shutdown signal is caught.
+* Grace period is canceled and Close is called immediatly if a second signal is received.
+
 # Manners
 
 A *polite* webserver for Go.
@@ -29,4 +36,4 @@ Manners 0.3.0 and above uses standard library functionality introduced in Go 1.3
 
 ### Installation
 
-`go get github.com/braintree/manners`
+`go get github.com/turbine/manners`

--- a/static.go
+++ b/static.go
@@ -1,19 +1,30 @@
 package manners
 
 import (
+	"log"
 	"net"
 	"net/http"
+	"os"
+	"os/signal"
 	"sync"
+	"syscall"
+	"time"
+)
+
+const (
+	DefaultGracePeriod = 15 * time.Second
 )
 
 var (
 	servers []*GracefulServer
 	m       sync.Mutex
+	signals sync.Once
 )
 
 // ListenAndServe provides a graceful version of the function provided by the net/http package.
 // Call Close() to stop all started servers.
 func ListenAndServe(addr string, handler http.Handler) error {
+	registerShutdownSignals()
 	server := NewWithServer(&http.Server{Addr: addr, Handler: handler})
 	m.Lock()
 	servers = append(servers, server)
@@ -24,6 +35,7 @@ func ListenAndServe(addr string, handler http.Handler) error {
 // ListenAndServeTLS provides a graceful version of the function provided by the net/http package.
 // Call Close() to stop all started servers.
 func ListenAndServeTLS(addr string, certFile string, keyFile string, handler http.Handler) error {
+	registerShutdownSignals()
 	server := NewWithServer(&http.Server{Addr: addr, Handler: handler})
 	m.Lock()
 	servers = append(servers, server)
@@ -34,6 +46,7 @@ func ListenAndServeTLS(addr string, certFile string, keyFile string, handler htt
 // Serve provides a graceful version of the function provided by the net/http package.
 // Call Close() to stop all started servers.
 func Serve(l net.Listener, handler http.Handler) error {
+	registerShutdownSignals()
 	server := NewWithServer(&http.Server{Handler: handler})
 	m.Lock()
 	servers = append(servers, server)
@@ -50,4 +63,27 @@ func Close() {
 	}
 	servers = nil
 	m.Unlock()
+}
+
+func registerShutdownSignals() {
+	signals.Do(func() {
+		sigc := make(chan os.Signal, 1)
+		signal.Notify(sigc,
+			syscall.SIGHUP,
+			syscall.SIGINT,
+			syscall.SIGTERM,
+			syscall.SIGQUIT)
+		go func() {
+			<-sigc
+			log.Printf("Beginning grace period (%s)\n", DefaultGracePeriod)
+			select {
+			// If a second signal is received, abandon ship and exit immediatly
+			case <-sigc:
+				log.Println("Canceled grace period")
+			case <-time.After(DefaultGracePeriod):
+			}
+			Close()
+			log.Println("Listeners closed")
+		}()
+	})
 }


### PR DESCRIPTION
Static manners functions will now register for shutdown signals. When signals are caught, wait 15 seconds before actually closing the listener to account for DNS lag. Cancel grace period if a second signal is received.
